### PR TITLE
bump version to 0.1.1 for registering

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pinecone"
 uuid = "ee90fdae-f7f0-4648-8b00-9c0307cf46d9"
 authors = ["Tim Tully <tim@menlovc.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"


### PR DESCRIPTION
Hello! could we register a new version for this package? It would be nice to use the version from the General Registry to use with HTTP 1.0+!

Thanks,
Panagiotis