### PR TITLE
Removed `dumpexception`

### DIFF
--- a/src/Pinecone.jl
+++ b/src/Pinecone.jl
@@ -69,10 +69,9 @@ context = Pinecone.init("abcd-123456-zyx", "us-west1-gcp")
 """
 function init(apikey::String, environment::String)
     response = pineconeHTTPGet(pineconeMakeURLForController(environment, ENDPOINTWHOAMI), apikey)
-    if response != nothing && response.status == 200
-        rvdict = pineconeGetDict(String(response.body))
-        return PineconeContext(apikey, environment, rvdict["project_name"])
-    end
+    
+    rvdict = pineconeGetDict(String(response.body))
+    return PineconeContext(apikey, environment, rvdict["project_name"])
 end #init
 
 # note no repsonse body from create, derive success from the HTTP 204
@@ -109,7 +108,6 @@ function create_index(ctx::PineconeContext, indexname::String, dimension::Int64;
     postbody = Dict{String, Any}("name"=>indexname, "dimension"=>dimension, "metric"=>metric, "replicas"=>replicas, "shards"=>shards, "pods"=>pods)
   
     response = pineconeHTTPPost(url, ctx, JSON3.write(postbody))
-    response != nothing && (response.status >= 200 && response.status < 300)
 end  #create_index
 
 """
@@ -153,9 +151,8 @@ function upsert(ctx::PineconeContext, indexobj::PineconeIndex, vectors::Vector{P
     end
     postbody = JSON3.write(body)
     response = pineconeHTTPPost(url, ctx, postbody)
-    if response != nothing && response.status == 200
-        return String(response.body)
-    end
+
+    return String(response.body)
 end #upsert
 
 """
@@ -267,9 +264,8 @@ function query(ctx::PineconeContext, indexobj::PineconeIndex, queries::Vector{Ve
     end
     postbody = JSON3.write(body)
     response = pineconeHTTPPost(url, ctx, postbody)
-    if response != nothing && (response.status == 200 || response.status == 400)
-        return String(response.body)
-    end
+        
+    return String(response.body)
 end #query
 
 """
@@ -295,9 +291,8 @@ function fetch(ctx::PineconeContext, indexobj::PineconeIndex, ids::Array{String}
     urlargs = "?" * join(renamedids, "&") * "&namespace=$namespace"
     url = pineconeMakeURLForIndex(indexobj, ctx, ENDPOINTFETCH) * urlargs
     response = pineconeHTTPGet(url, ctx)
-    if response != nothing && (response.status == 200 || response.status == 400)
-        return String(response.body)
-    end
+    
+    return String(response.body)
 end
 
 """
@@ -322,9 +317,8 @@ function delete(ctx::PineconeContext, indexobj::PineconeIndex, ids::Array{String
     urlargs = "?" * join(renamedids, "&") * "&deleteAll=" * string(deleteall) * "&namespace=$namespace"
     url = pineconeMakeURLForIndex(indexobj, ctx, ENDPOINTDELETE) * urlargs
     response = pineconeHTTPDelete(url, ctx)
-    if response != nothing && (response.status == 200 || response.status == 400)
-        return String(response.body)
-    end
+        
+    return String(response.body)
 end
 
 """
@@ -341,9 +335,7 @@ Pinecone.list_indexes(context)
 """
 function list_indexes(context::PineconeContext)
     response = pineconeHTTPGet(pineconeMakeURLForController(context.cloudenvironment, ENDPOINTLISTINDEXES), context)
-    if response != nothing && response.status == 200
-        return String(response.body)
-    end
+    return String(response.body)
 end
 
 """ 
@@ -359,9 +351,7 @@ Pinecone.whoami(context)
 """
 function whoami(context::PineconeContext)
     response = pineconeHTTPGet(pineconeMakeURLForController(context.cloudenvironment, ENDPOINTWHOAMI), context)
-    if response != nothing && response.status == 200
-        return String(response.body)
-    end
+    return String(response.body)
 end
 
 """
@@ -379,7 +369,6 @@ Pinecone.delete_index(context, Pinecone.Index("index-to-delete"))
 function delete_index(ctx::PineconeContext, indexobj::PineconeIndex)
     url = pineconeMakeURLForController(ctx.cloudenvironment, ENDPOINTDELETEINDEX * "/" * indexobj.indexname)
     response = pineconeHTTPDelete(url, ctx)
-    response !== nothing && response.status == 202
 end
 
 """
@@ -398,9 +387,7 @@ Pinecone.describe_index_stats(context, index)
 function describe_index_stats(ctx::PineconeContext, indexobj::PineconeIndex)
     url = pineconeMakeURLForIndex(indexobj, ctx, ENDPOINTDESCRIBEINDEXSTATS)
     response = pineconeHTTPGet(url, ctx)
-    if response != nothing && response.status == 200
-        return String(response.body)
-    end
+    return String(response.body)
 end
 
 """
@@ -424,7 +411,6 @@ function scale_index(ctx::PineconeContext, indexobj::PineconeIndex, replicas::In
     response = pineconeHTTPPatch(url, ctx, JSON3.write(postbody))
     # we get back 204, docs say 200 but they're wrong
     # https://www.pinecone.io/docs/api/operation/scale_index/
-    response != nothing && (response.status >= 200 && response.status <= 204) 
 end
 
 

--- a/src/networking.jl
+++ b/src/networking.jl
@@ -7,14 +7,8 @@ const HEADER_CONTENT_TYPE = "Content-Type"
 const CONTENT_TYPE_JSON = "Content-Type: application/json"
 
 function dohttp(method, url, headers, body::String="")
-    try
-        HTTP.request(method, url, headers, body)
-    catch e
-        dumpexception(e)
-    end
+    HTTP.request(method, url, headers, body)
 end
-
-dumpexception(e) = println("Error communicating with Pinecone service.  Exception is: \n", e)
 
 pineconeHTTPGet(url::String, ctx::Pinecone.PineconeContext) = begin
     dohttp("GET", url,[HEADER_API_KEY=>ctx.apikey])


### PR DESCRIPTION
Resolves #11. This PR removed the `dumpexception` function along with the `try`/`catch` block that prevents the raw HTTP error from being displayed.

Now I might be missing something with this whole thing, but I just see it as very unnecessary to catch the error and then have to check for if nothing is returned for every type of HTTP request. Why not just let the error interrupt the program and end it?