### PR TITLE
fix precompile

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,16 +1,21 @@
 name = "Pinecone"
 uuid = "ee90fdae-f7f0-4648-8b00-9c0307cf46d9"
 authors = ["Tim Tully <tim@menlovc.com>"]
-version = "2.0"
+version = "2.1"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 HTTP = "0.9, 1"
 JSON3 = "1"
 StructTypes = "1"
 julia = "1.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/src/Pinecone.jl
+++ b/src/Pinecone.jl
@@ -1,5 +1,3 @@
-__precompile__(false)
-
 module Pinecone
 
 using JSON3 
@@ -50,9 +48,6 @@ const MAX_TOPK_WITH_DATA = 1000
 const MAX_DIMS = 10000
 const MAX_DELETE = 1000
 
-function __init__()
-    nothing
-end
 
 """
     init(apikey::String, environment::String)


### PR DESCRIPTION
Not sure what it was for, but `__precompile__(false)` breaks precompile for the whole package 
Seems to be working fine without it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package version to 2.1.
  - Adjusted the handling of the testing dependency to be optional.
  - Made minor internal cleanup with no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->